### PR TITLE
Fix credit notes allocation

### DIFF
--- a/lib/xeroizer/models/credit_note.rb
+++ b/lib/xeroizer/models/credit_note.rb
@@ -130,10 +130,10 @@ module Xeroizer
         def save
           # Calling parse_save_response() on the credit note will wipe out
           # the allocations, so we have to manually preserve them.
-          allocations_backup = allocations
+          allocations_backup = self.allocations
           if super
-            allocations = allocations_backup
-            allocate if !allocations.empty?
+            self.allocations = allocations_backup
+            allocate unless self.allocations.empty?
             true
           end
         end


### PR DESCRIPTION
It was apparently not working without `self.` and thus was sending an empty allocation to Xero API which caused HTTP 500 errors on their side.
